### PR TITLE
llama-perplexity: add new experiment to measure model perplexity

### DIFF
--- a/llama-perplexity/README.md
+++ b/llama-perplexity/README.md
@@ -1,0 +1,66 @@
+# Llama Benchmarks
+
+A set of experiments for evaluating LLM performance using SystemsLab. These
+experiments are intended to run on machines with Nvidia GPUs.
+
+## Prerequisites
+
+`perplexity` from `llama.cpp` is built and located at
+`/usr/local/bin/llama-perplexity`. The repo and build instructions can be found
+[here][llama.cpp]
+
+When `AUTODOWNLOAD` is enabled, the `huggingface-cli` tool must be available in
+the `PATH`.
+
+*Note:* be sure you have CUDA toolkit already installed and build with the
+options to enable CUDA acceleration.
+
+## Model Downloads
+
+This experiment assumes that we are measuring the performance of GGUF quantized
+weights. You can download these models from Hugging Face. For example, the Llama
+2 7B model can be found [here][Llama-2-7B-GGUF]. At this time we also assume
+that the quantized models are provided by `TheBloke` or for OpenLlama by
+`brayniac`.
+
+There are two ways for model weights to be provided. One is to let the
+experiment automatically download from HuggingFace. This is optimized for cloud
+usage where ingress bandwidth is free and plentiful but disk space on the
+runners has a significant impact on cost to run. For this mode, leave
+`AUTODOWNLOAD` set to `1` in the run script. The experiment will automatically
+fetch the quantized model weights for that run, and they will be deleted on
+experiment completion.
+
+For local runs of experiments, this is an inefficient approach. Disk space to
+host the weights either on the runner or on an NFS mount is cheap, and bandwidth
+is limited. In that case, it is expected that the weights for each model are
+kept in `/mnt/models/${MODEL}`. The user is expected to pre-download all the
+model weights they need using the `hugggingface-cli` tool.
+
+## Parameters
+
+* model - the name of the model to use, eg: `Llama-2-7B` note that we do not 
+  provide the `-GGUF` suffix
+* quantization - the quantization format eg: `Q4_K_M`
+* powercap - specify a power limit to be applied to all Nvidia GPUs in the
+  system. A powercap of `0` results in the default power limit for the card
+  being used.
+* context - the size of the prompt context
+* gpu - a gpu model for the experiments, used as a scheduling constraint and in
+  the experiment name.
+
+## Artifacts
+
+* output.json - the JSON output of the llama-bench command which includes
+  metrics about inference performance.
+* metrics.json - the automatically collected Rezolus metrics which capture
+  system-level performance data.
+
+## Proposed Analysis Goals
+
+* Compare models to find which have better perplexity.
+* See how model size impacts perplexity.
+* Evaluate how different quantization methods impact perplexity.
+
+[llama.cpp]: https://github.com/ggerganov/llama.cpp
+[Llama-2-7B-GGUF]: https://huggingface.co/TheBloke/Llama-2-7B-GGUF

--- a/llama-perplexity/llama_perplexity.jsonnet
+++ b/llama-perplexity/llama_perplexity.jsonnet
@@ -1,0 +1,80 @@
+function(model='Llama-2-7B', quantization='Q4_K_M', powercap='0', gpu='rtx2080ti', context='512', autodownload='1')
+    local args = {
+        model: model,
+        quantization: quantization,
+        powercap: powercap,
+        gpu: gpu,
+        context: context,
+        autodownload: autodownload,
+    };
+    local
+        context = std.parseInt(args.context),
+        powercap = std.parseInt(args.powercap),
+        autodownload = std.parseInt(args.autodownload);
+    {
+        name: 'perplexity_%(model)s_%(quantization)s_ctx%(context)i' % {
+            model: model,
+            quantization: quantization,
+            context: context,
+        },
+        jobs: {
+            perplexity: {
+                host: {
+                    tags: ['%(gpu)s' % { gpu: gpu }],
+                },
+                steps: [
+                    systemslab.bash(
+                        |||
+                            echo "environment setup..."
+                            export HOME=`pwd`
+
+                            echo "setting powercap..."
+                            if [ %(powercap)i -eq 0 ]; then
+                                sudo nvidia-smi -pl `nvidia-smi -q | grep "Default Power Limit" | awk '{print $5}' | head -1`
+                            else
+                                sudo nvidia-smi -pl %(powercap)i
+                            fi
+
+                            MODEL="%(model)s-GGUF"
+                            HFUSER="TheBloke"
+                            MODEL_FAMILY=`echo ${MODEL} | awk -F- '{print $1}'`
+                            QUANTIZATION="%(quantization)s"
+
+                            if [ "${MODEL_FAMILY}" == "OpenLlama" ]; then
+                                HFUSER="brayniac"
+                            fi
+
+                            echo "downloading test file..."
+                            curl -O -L https://huggingface.co/datasets/ggml-org/ci/resolve/main/wikitext-2-raw-v1.zip
+                            unzip wikitext-2-raw-v1.zip
+                            ls -l wikitext-2-raw
+
+                            if [ %(autodownload)i -eq 1 ]; then
+                                echo "downloading model..."
+                                huggingface-cli download ${HFUSER}/${MODEL} --local-dir . --local-dir-use-symlinks False --include="*${QUANTIZATION}.gguf"
+                                ls -l *.gguf
+                            fi
+
+                            PATHPREFIX=".";
+
+                            if [ %(autodownload)i -eq 0 ]; then 
+                                PATHPREFIX="/mnt/models/${MODEL}";
+                            fi
+
+                            echo "running test..."
+                            /usr/local/bin/llama-perplexity -m ${PATHPREFIX}/*${QUANTIZATION}.gguf -f ./wikitext-2-raw/wiki.test.raw --n-gpu-layers 99 -c %(context)i | tee output.log
+                        ||| % {
+                            model: model,
+                            quantization: quantization,
+                            powercap: powercap,
+                            context: context,
+                        },
+                        background=false
+                    ),
+
+                    // Upload the artifacts
+                    systemslab.upload_artifact('output.log'),
+                ],
+            },
+        },
+    }

--- a/llama-perplexity/run.sh
+++ b/llama-perplexity/run.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -x
+set -eu
+
+SYSTEMSLAB_URL="${SYSTEMSLAB_URL:-http://systemslab}"
+SYSTEMSLAB=${SYSTEMSLAB:-systemslab}
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# The GPU model to be use in the tests. Must match the agent tags
+GPU=l4
+
+# Controls whether the model weights are automatically downloaded for each
+# experiment.
+AUTODOWNLOAD=1
+
+# Specify model names to test here
+MODEL=(
+    Llama-7B
+    Llama-13B
+    Llama-30B
+    Llama-2-7B
+    Llama-2-13B
+    OpenLlama-3B
+    OpenLlama-3B-v2
+    OpenLlama-7B
+    OpenLlama-7B-v2
+    OpenLlama-13B
+)
+
+# Specify quantization strategies to test here
+QUANTIZATION=(
+    Q2_K
+    Q3_K_L
+    Q3_K_M
+    Q3_K_S
+    Q4_0
+    Q4_K_M
+    Q4_K_S
+    Q5_0
+    Q5_K_M
+    Q5_K_S
+    Q6_K
+    Q8_0
+    # fp16
+)
+
+CONTEXT=(
+    128
+    256
+    384
+    512
+    640
+    768
+    896
+    1024
+    1152
+    1280
+    1408
+    1536
+    1664
+    1792
+    1920
+    2048
+    2176
+    2304
+    2432
+    2560
+    2688
+    2816
+    2944
+    3072
+    3200
+    3328
+    3456
+    3584
+    3712
+    3840
+    3968
+    4096
+)
+
+# Sets a power limit on the GPU (assumes Nvidia). A value of `0` uses the GPU's
+# default power limit. This value is in Watts.
+POWERCAP=0
+
+cd "$SCRIPT_DIR"
+
+for model in "${MODEL[@]}"; do
+    for quantization in "${QUANTIZATION[@]}"; do
+        for context in "${CONTEXT[@]}"; do
+            $SYSTEMSLAB submit \
+                --output-format short \
+                --param "model=$model" \
+                --param "quantization=$quantization" \
+                --param "powercap=$POWERCAP" \
+                --param "gpu=$GPU" \
+                --param "context=$context" \
+                --param "autodownload=$AUTODOWNLOAD" \
+                llama_perplexity.jsonnet
+        done
+    done
+done


### PR DESCRIPTION
Adds a new experiment that measures model perplexity using the wikitext-2 dataset.